### PR TITLE
Update Q14 net revenue calculation

### DIFF
--- a/Practice/list_lambda_map_filter_questions.ipynb
+++ b/Practice/list_lambda_map_filter_questions.ipynb
@@ -312,14 +312,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "2b601ffe",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[900.0, 1800.0, 2700.0]\n"
+     ]
+    }
+   ],
    "source": [
     "# Solution for Q14\n",
     "revenues = [1000, 2000, 3000]\n",
-    "net_profit = list(map(lambda amount: amount * 0.7, revenues))  # assume 30% costs\n",
+    "net_profit = list(map(lambda amount: amount * 0.9, revenues))  # assume 10% tax\n",
     "print(net_profit)"
    ]
   },


### PR DESCRIPTION
## Summary
- adjust Q14 solution to apply a 10% tax deduction when calculating net revenue
- update the accompanying comment to clarify that the deduction represents tax
- execute the notebook cell so the displayed output reflects the revised calculation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ee526052fc83238d5b5c606fa4846e