### PR TITLE
Increase Q11 price hike to 15 percent

### DIFF
--- a/Practice/list_lambda_map_filter_questions.ipynb
+++ b/Practice/list_lambda_map_filter_questions.ipynb
@@ -249,14 +249,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "345e12ae",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[114.99999999999999, 229.99999999999997, 345.0]\n"
+     ]
+    }
+   ],
    "source": [
     "# Solution for Q11\n",
     "prices = [100, 200, 300]\n",
-    "updated_prices = list(map(lambda price: price * 1.05, prices))  # apply 5% hike\n",
+    "updated_prices = list(map(lambda price: price * 1.15, prices))  # apply 15% hike\n",
     "print(updated_prices)"
    ]
   },


### PR DESCRIPTION
## Summary
- update the Q11 solution to apply a 15% price increase and adjust the inline comment
- execute the solution cell so the stored output reflects the new 15% pricing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ee525d93b48323bfe3895220ba9280