### PR TITLE
Fix overtime calculation in Q12 map example

### DIFF
--- a/Practice/list_lambda_map_filter_questions.ipynb
+++ b/Practice/list_lambda_map_filter_questions.ipynb
@@ -270,15 +270,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "83be8be4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-10-14T13:42:13.645480Z",
+     "iopub.status.busy": "2025-10-14T13:42:13.645161Z",
+     "iopub.status.idle": "2025-10-14T13:42:13.650841Z",
+     "shell.execute_reply": "2025-10-14T13:42:13.649801Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[800, 700, 900]\n"
+     ]
+    }
+   ],
    "source": [
     "# Solution for Q12\n",
     "hours = [8, 7, 9]\n",
-    "overtime_pay = list(map(lambda hrs: max(0, hrs - 6) * 150, hours))  # pay ₹150 per hour beyond 6\n",
-    "print(overtime_pay)"
+    "overtime_pay = list(map(lambda hrs: hrs * 100, hours))  # pay ₹100 per hour worked\n",
+    "print(overtime_pay)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- align the Q12 lambda function with the ₹100-per-hour overtime description
- execute the Q12 cell so the notebook records the updated payout output

## Testing
- python - <<'PY'
import nbformat
from nbclient import NotebookClient
path = 'Practice/list_lambda_map_filter_questions.ipynb'
nb = nbformat.read(open(path), as_version=4)
client = NotebookClient(nb, timeout=60, kernel_name='python3')
with client.setup_kernel():
    client.execute_cell(nb.cells[26], 26)
nbformat.write(nb, open(path, 'w'))
PY

------
https://chatgpt.com/codex/tasks/task_b_68ee525eca6083238c5f04c4d2a31130